### PR TITLE
Use Shiki for syntax highlighting

### DIFF
--- a/build_production/newsletter-1.html
+++ b/build_production/newsletter-1.html
@@ -99,19 +99,19 @@
       .sm-block {
         display: block !important;
       }
-      .sm-w-full {
-        width: 100% !important;
-      }
       .sm-w-12 {
         width: 48px !important;
       }
-      .sm-px-4 {
-        padding-left: 16px !important;
-        padding-right: 16px !important;
+      .sm-w-full {
+        width: 100% !important;
       }
       .sm-px-0 {
         padding-left: 0 !important;
         padding-right: 0 !important;
+      }
+      .sm-px-4 {
+        padding-left: 16px !important;
+        padding-right: 16px !important;
       }
       .sm-pb-8 {
         padding-bottom: 32px !important;
@@ -119,7 +119,7 @@
     }
   </style>
 </head>
-<body style="word-break: break-word; -webkit-font-smoothing: antialiased; margin: 0; width: 100%; background-color: #0F172A; padding: 0">
+<body style="-webkit-font-smoothing: antialiased; word-break: break-word; margin: 0; width: 100%; background-color: #0F172A; padding: 0">
   <div align="center" role="article" aria-roledescription="email" lang="en" class="sm-px-4" aria-label="Edition #1: Using Markdown to create HTML emails with Maizzle" style="background-color: #0F172A">
     <div style="line-height: 40px" role="separator">&zwnj;</div>
     <div style="text-align: center">
@@ -177,10 +177,10 @@
                   <p style="color: #475569; margin: 0; font-size: 18px; line-height: 28px;">One small step for man, one giant leap for mankind.</p>
                 </blockquote>
                 <p style="font-size: 16px; line-height: 24px; color: #475569; margin: 0 0 32px;">It even supports code blocks:</p>
-                <pre style="margin-bottom: 24px; overflow: auto; white-space: pre; border-radius: 8px; padding: 24px; text-align: left; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 16px; background-color: #0F172A; color: #cbd5e1; background-image: linear-gradient(to bottom, #0F172A 25%, #17223c); hyphens: none; tab-size: 2; word-break: normal; word-spacing: normal; word-wrap: normal"><code class="language-html">&lt;p class=&quot;text-lg&quot;&gt;
-  &lt;a href=&quot;https://maizzle.com&quot;&gt;Maizzle&lt;/a&gt; is a framework for building responsive HTML emails with Tailwind CSS.
-&lt;/p&gt;
-</code></pre>
+                <pre style="margin-bottom: 24px; overflow: auto; white-space: pre; border-radius: 8px; padding: 24px; text-align: left; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 16px; color: #cbd5e1; hyphens: none; tab-size: 2; word-break: normal; word-spacing: normal; word-wrap: normal; background-color: #292D3E" tabindex="0"><code><span><span style="color: #89DDFF">&lt;</span><span style="color: #F07178">p</span><span style="color: #89DDFF"> </span><span style="color: #C792EA">class</span><span style="color: #89DDFF">=</span><span style="color: #89DDFF">&quot;</span><span style="color: #C3E88D">text-lg</span><span style="color: #89DDFF">&quot;</span><span style="color: #89DDFF">&gt;</span></span>
+<span><span style="color: #A6ACCD">  </span><span style="color: #89DDFF">&lt;</span><span style="color: #F07178">a</span><span style="color: #89DDFF"> </span><span style="color: #C792EA">href</span><span style="color: #89DDFF">=</span><span style="color: #89DDFF">&quot;</span><span style="color: #C3E88D">https://maizzle.com</span><span style="color: #89DDFF">&quot;</span><span style="color: #89DDFF">&gt;</span><span style="color: #A6ACCD">Maizzle</span><span style="color: #89DDFF">&lt;/</span><span style="color: #F07178">a</span><span style="color: #89DDFF">&gt;</span><span style="color: #A6ACCD"> is a framework for building responsive HTML emails with Tailwind CSS.</span></span>
+<span><span style="color: #89DDFF">&lt;/</span><span style="color: #F07178">p</span><span style="color: #89DDFF">&gt;</span></span>
+<span></span></code></pre>
                 <p style="font-size: 16px; line-height: 24px; color: #475569; margin: 0 0 32px;">Cheers,<br>
                   The Maizzle Team</p>
               </td>

--- a/build_production/newsletter-2.html
+++ b/build_production/newsletter-2.html
@@ -119,19 +119,19 @@
       .sm-block {
         display: block !important;
       }
-      .sm-w-full {
-        width: 100% !important;
-      }
       .sm-w-12 {
         width: 48px !important;
       }
-      .sm-px-4 {
-        padding-left: 16px !important;
-        padding-right: 16px !important;
+      .sm-w-full {
+        width: 100% !important;
       }
       .sm-px-0 {
         padding-left: 0 !important;
         padding-right: 0 !important;
+      }
+      .sm-px-4 {
+        padding-left: 16px !important;
+        padding-right: 16px !important;
       }
       .sm-pb-8 {
         padding-bottom: 32px !important;
@@ -139,7 +139,7 @@
     }
   </style>
 </head>
-<body style="word-break: break-word; -webkit-font-smoothing: antialiased; margin: 0; width: 100%; background-color: #0F172A; padding: 0">
+<body style="-webkit-font-smoothing: antialiased; word-break: break-word; margin: 0; width: 100%; background-color: #0F172A; padding: 0">
   <div align="center" role="article" aria-roledescription="email" lang="en" class="sm-px-4" aria-label="Edition #2: Using a custom layout" style="background-color: #0F172A">
     <div style="line-height: 40px" role="separator">&zwnj;</div>
     <table cellpadding="0" cellspacing="0" role="presentation">
@@ -165,10 +165,10 @@
                 <h1 style="font-size: 30px; line-height: 36px; color: #0f172a; margin: 0 0 40px">Edition #2: Using a custom layout</h1>
                 <p style="font-size: 16px; line-height: 24px; color: #475569; margin: 0 0 32px">This edition uses a custom layout: the header shows a different logo image, which is now also left-aligned instead of centered.</p>
                 <p style="font-size: 16px; line-height: 24px; color: #475569; margin: 0 0 32px;">This is done via the <code style="border-radius: 4px; padding: 2px 6px; white-space: normal; font-size: 14px; border: 1px solid #e2e8f0; background-color: #f8fafc; color: #ec4899;">layout</code> property in the front matter:</p>
-                <pre style="margin-bottom: 24px; overflow: auto; white-space: pre; border-radius: 8px; padding: 24px; text-align: left; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 16px; background-color: #0F172A; color: #cbd5e1; background-image: linear-gradient(to bottom, #0F172A 25%, #17223c); hyphens: none; tab-size: 2; word-break: normal; word-spacing: normal; word-wrap: normal"><code class="language-yaml">---
-layout: secondary
----
-</code></pre>
+                <pre style="margin-bottom: 24px; overflow: auto; white-space: pre; border-radius: 8px; padding: 24px; text-align: left; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 16px; color: #cbd5e1; hyphens: none; tab-size: 2; word-break: normal; word-spacing: normal; word-wrap: normal; background-color: #292D3E" tabindex="0"><code><span><span style="color: #FFCB6B">---</span></span>
+<span><span style="color: #F07178">layout</span><span style="color: #89DDFF">:</span><span style="color: #A6ACCD"> </span><span style="color: #C3E88D">secondary</span></span>
+<span><span style="color: #FFCB6B">---</span></span>
+<span></span></code></pre>
                 <p style="font-size: 16px; line-height: 24px; color: #475569; margin: 0 0 32px;">The value of <code style="border-radius: 4px; padding: 2px 6px; white-space: normal; font-size: 14px; border: 1px solid #e2e8f0; background-color: #f8fafc; color: #ec4899;">layout</code> must match one of the file names inside the <code style="border-radius: 4px; padding: 2px 6px; white-space: normal; font-size: 14px; border: 1px solid #e2e8f0; background-color: #f8fafc; color: #ec4899;">src/layouts</code> directory.</p>
                 <p style="font-size: 16px; line-height: 24px; color: #475569; margin: 0 0 32px;">Cheers,<br>
                   The Maizzle Team</p>

--- a/config.js
+++ b/config.js
@@ -10,6 +10,7 @@
 */
 
 const fm = require('front-matter')
+const shiki = require('shiki')
 
 module.exports = {
   baseURL: {
@@ -37,6 +38,22 @@ module.exports = {
     ]
   },
   events: {
+    async beforeCreate(config) {
+      const highlighter = await shiki.getHighlighter({
+        theme: 'material-theme-palenight',
+      })
+
+      config = Object.assign(config, {
+        markdown: {
+          markdownit: {
+            highlight: (code, lang) => {
+              lang = lang || 'html'
+              return highlighter.codeToHtml(code, { lang })
+            }
+          }
+        }
+      })
+    },
     beforeRender(html) {
       const { attributes, body } = fm(html)
       const layout = attributes.layout || 'main'

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@maizzle/framework": "next",
     "front-matter": "^4.0.2",
     "markdown-it-attrs": "^4.1.4",
+    "shiki": "^0.14.1",
     "tailwindcss-box-shadow": "^2.0.0",
     "tailwindcss-email-variants": "^2.0.0",
     "tailwindcss-mso": "^1.3.0"

--- a/src/css/markdown.css
+++ b/src/css/markdown.css
@@ -73,8 +73,7 @@ a {
 pre {
   @apply p-6 mb-6 overflow-auto whitespace-pre rounded-lg;
   @apply font-mono text-base text-left;
-  @apply text-slate-300 bg-[#0F172A];
-  background-image: linear-gradient(to bottom, #0F172A 25%, #17223c);
+  @apply text-slate-300;
   hyphens: none;
   tab-size: 2;
   word-break: normal;


### PR DESCRIPTION
This PR adds [Shiki](https://shiki.matsu.io/) as the default syntax highlighter for markdown-it.